### PR TITLE
Add starter Python project scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # codeztest
+
+This is a minimal Python project scaffold. It includes a basic CLI that prints a greeting.
+
+## Development
+
+To run the command line interface directly:
+
+```bash
+python -m codeztest
+```
+
+Run the tests with:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codeztest"
+version = "0.1.0"
+description = "Starter Python project"
+authors = [{name = "codeztest authors"}]
+requires-python = ">=3.8"
+
+[project.scripts]
+codeztest = "codeztest.cli:main"

--- a/src/codeztest/__init__.py
+++ b/src/codeztest/__init__.py
@@ -1,0 +1,6 @@
+__all__ = ["hello"]
+
+
+def hello(name: str = "world") -> str:
+    """Return a greeting for the given name."""
+    return f"Hello, {name}!"

--- a/src/codeztest/__main__.py
+++ b/src/codeztest/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running `python -m codeztest`."""
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codeztest/cli.py
+++ b/src/codeztest/cli.py
@@ -1,0 +1,16 @@
+"""Command line interface for codeztest."""
+
+import argparse
+from . import hello
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="codeztest CLI")
+    parser.add_argument("name", nargs="?", default="world", help="Name to greet")
+    args = parser.parse_args(argv)
+    print(hello(args.name))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,7 @@
+from codeztest.cli import main
+
+
+def test_cli_output(capsys):
+    assert main([]) == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "Hello, world!"


### PR DESCRIPTION
## Summary
- initialize minimal Python project with greeting CLI
- add pyproject configuration with setuptools
- document how to run the CLI and tests
- include simple unit test for CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687454231e3483319ab2b4cc45ade71a